### PR TITLE
Update requirements.txt

### DIFF
--- a/generated_text_detector/requirements.txt
+++ b/generated_text_detector/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.12.3
 fastapi==0.110.0
 Markdown==3.7
-numpy==1.25.2
+numpy>=1.25.2
 nltk==3.8.1
 starlette==0.36.3
 torch==2.2.1


### PR DESCRIPTION
For the package to work in Python 3.12, numpy version 1.26.4 is required. This way the requirement works for those who have the newer version installed.